### PR TITLE
YIO ENV variables and build version from Git tag

### DIFF
--- a/overlay/etc/profile.d/yio.sh
+++ b/overlay/etc/profile.d/yio.sh
@@ -1,0 +1,7 @@
+export YIO_HOME=/usr/bin/yio-remote
+# remote-os release, set during build
+export YIO_OS_VERSION=$BUILD_VERSION
+# Git hash of the remote-os repo, set during build
+export YIO_OS_GITHASH=$GIT_HASH
+export YIO_LOG_DIR=/var/log
+export YIO_LOG_DIR_UPDATE=/boot/log

--- a/rpi0/git-version.sh
+++ b/rpi0/git-version.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Build version retrieval script.
+# Prints the current version or 'UNKNOWN' if version could not be determined.
+#
+# 1. see if there is a version file (provided as first argument)
+# 2. then try git-describe to retrieve version tag
+#    - append '-dirty' if local changes are found
+# 3. otherwise fallback: 'UNKNOWN'
+#
+# Inspired by:
+# https://git.kernel.org/pub/scm/git/git.git/tree/GIT-VERSION-GEN?id=HEAD
+
+VERSION_FILE=$1
+DEF_VER=UNKNOWN
+LF='
+'
+
+if test -f "$VERSION_FILE"
+then
+	BUILD_VERSION=$(cat "$VERSION_FILE") || BUILD_VERSION="$DEF_VER"
+elif BUILD_VERSION=$(git describe --match "v[0-9]*" --tags HEAD 2>/dev/null) &&
+	case "$BUILD_VERSION" in
+	*$LF*) (exit 1) ;;
+	v[0-9]*)
+	    # added or modified files? Mark it dirty! (New files are not considered)
+		git update-index -q --refresh
+		test -z "$(git diff-index --name-only HEAD --)" || BUILD_VERSION="$BUILD_VERSION-dirty" ;;
+	esac
+then
+    # here we could adjust the version from the Git tag. E.g. replace dash with dot
+	# BUILD_VERSION=$(echo "$BUILD_VERSION" | sed -e 's/-/./g');
+	:
+else
+    # TODO add version logic for develop and feature branches?
+	BUILD_VERSION="$DEF_VER"
+fi
+
+# strip leading 'v'
+BUILD_VERSION=$(expr "$BUILD_VERSION" : v*'\(.*\)')
+
+echo $BUILD_VERSION

--- a/rpi0/git-version.sh
+++ b/rpi0/git-version.sh
@@ -6,6 +6,12 @@
 # 1. see if there is a version file (provided as first argument)
 # 2. then try git-describe to retrieve version tag
 #    - append '-dirty' if local changes are found
+#    - see: https://git-scm.com/docs/git-describe
+#    Examples:
+#    - build from a version tag: v0.2.0
+#    - build from a develop branch which is 16 commits ahead of the latest
+#      version tag: v0.2.0-16-g60e1688
+#    - build with local modifications: v0.2.0-16-g60e1688-dirty
 # 3. otherwise fallback: 'UNKNOWN'
 #
 # Inspired by:
@@ -19,6 +25,8 @@ LF='
 if test -f "$VERSION_FILE"
 then
 	BUILD_VERSION=$(cat "$VERSION_FILE") || BUILD_VERSION="$DEF_VER"
+# get version from last release tag (e.g. v0.2.0)
+# see https://git-scm.com/docs/git-describe
 elif BUILD_VERSION=$(git describe --match "v[0-9]*" --tags HEAD 2>/dev/null) &&
 	case "$BUILD_VERSION" in
 	*$LF*) (exit 1) ;;

--- a/rpi0/post-build.sh
+++ b/rpi0/post-build.sh
@@ -3,6 +3,8 @@
 set -u
 set -e
 
+SCRIPT_DIR=$(dirname $0)
+
 # Add a console on tty1
 if [ -e ${TARGET_DIR}/etc/inittab ]; then
     grep -qE '^tty1::' ${TARGET_DIR}/etc/inittab || \
@@ -25,3 +27,14 @@ rm -rf $1/var/log/journal
 
 #rm -r $1/etc/systemd/system/multi-user.target.wants/dhcpcd.service
 
+# Determine build version
+BUILD_VERSION=$("$SCRIPT_DIR/git-version.sh" "$BR2_EXTERNAL/version")
+
+# We need the Git hash of remote-os and not of the buildroot submodule!
+GIT_HASH=`cd $1; git rev-parse HEAD`
+
+echo "Setting build version in YIO env variable: $BUILD_VERSION"
+sed -i "s/\$BUILD_VERSION/$BUILD_VERSION/g" $1/etc/profile.d/yio.sh
+
+echo "Setting Git hash in YIO env variable: $GIT_HASH"
+sed -i "s/\$GIT_HASH/$GIT_HASH/g" $1/etc/profile.d/yio.sh


### PR DESCRIPTION
Defined YIO environment variables in /etc/profile.d/yio.sh

The version env var is replaced in the Buildroot build from the Git version tag (a release must have a tag) or read from an optional version file in project root directory.

Version:
1. see if there is a `version` file in the project root folder
2. then try git-describe to retrieve version tag
    - append '-dirty' if local changes are found
    - see: https://git-scm.com/docs/git-describe

    Examples:
    - build from a version tag: v0.2.0
    - build from a develop branch which is 16 commits ahead of the latest
      version tag: v0.2.0-16-g60e1688
    - build with local modifications: v0.2.0-16-g60e1688-dirty
3. otherwise fallback: 'UNKNOWN'


This closes #33