### PR TITLE
feat: Bluetooth console if marker file is present

### DIFF
--- a/overlay/etc/systemd/system/bluetooth.service.d/no-sap.conf
+++ b/overlay/etc/systemd/system/bluetooth.service.d/no-sap.conf
@@ -1,4 +1,5 @@
 [Service]
 # clear before override: https://stackoverflow.com/questions/34802345/systemd-how-to-clear-an-entry-when-overriding-a-unit-file/41572053#41572053
 ExecStart=
-ExecStart=/usr/libexec/bluetooth/bluetoothd --noplugin=sap
+# disable SIM access profile and enable compatability mode for serial console
+ExecStart=/usr/libexec/bluetooth/bluetoothd --noplugin=sap --compat

--- a/overlay/etc/systemd/system/multi-user.target.wants/rfcomm.service
+++ b/overlay/etc/systemd/system/multi-user.target.wants/rfcomm.service
@@ -1,0 +1,1 @@
+../rfcomm.service

--- a/overlay/etc/systemd/system/rfcomm.service
+++ b/overlay/etc/systemd/system/rfcomm.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=RFCOMM service
+After=bluetooth.service
+Requires=bluetooth.service
+RequiresMountsFor=/boot
+ConditionPathExists=/boot/btconsole
+
+[Service]
+ExecStartPre=/bin/sdptool add SP
+ExecStartPre=/bin/hciconfig hci0 up
+ExecStartPre=/bin/hciconfig hci0 piscan
+ExecStart=/bin/rfcomm watch hci0 1 getty rfcomm0 115200 vt100
+
+[Install]
+WantedBy=multi-user.target

--- a/patch/bluez5_utils/0100-tools-Fix-rfcomm-console-delay.patch
+++ b/patch/bluez5_utils/0100-tools-Fix-rfcomm-console-delay.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/rfcomm.c b/tools/rfcomm.c
+index 809c2404c..093552f6c 100644
+--- a/tools/rfcomm.c
++++ b/tools/rfcomm.c
+@@ -257,7 +257,7 @@ static void run_cmdline(struct pollfd *p, sigset_t *sigs, char *devname,
+ 
+ 			p->revents = 0;
+ 			ts.tv_sec  = 0;
+-			ts.tv_nsec = 200;
++			ts.tv_nsec = 200000000;
+ 			if (ppoll(p, 1, &ts, sigs) || __io_canceled) {
+ 				kill(pid, SIGTERM);
+ 				waitpid(pid, &status, 0);

--- a/rpi0/boot/README.md
+++ b/rpi0/boot/README.md
@@ -1,0 +1,37 @@
+# YIO remote-os
+
+- Version: $BUILD_VERSION
+- Build date: $BUILD_DATE
+
+## Boot Options
+
+### WiFi Configuration
+
+To use a pre-defined `wpa_supplicant.conf` for your WIFI network, put this file in the root of this boot partition.  
+This is required if you have a network using WEP or EAP, which are not supported in the remote-software WIFI configuration.
+
+You can use the `wpa_supplicant.conf.template` as a starting point. For further information, please see:
+
+- <https://www.raspberrypi.org/documentation/configuration/wireless/headless.md>
+- <https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf>
+
+Attention:
+
+- If a wpa_supplicant.conf file is present in /boot, the initial setup is skipped during first run.
+- The Raspberry Pi 0 W doesn't support 5GHz networks!
+
+### Bluetooth Serial Console
+
+To enable a Bluetooth serial console, create a marker file `btconsole` in the root of this boot partition.
+
+### Factory Reset
+
+To factory reset the configuration:
+
+1. Reboot remote
+2. When the YIO splashscreen appears, immediately press these 3 keys:
+   - Volume up
+   - Top left outlined circle
+   - DPad down
+3. The remote will automatically reboot and start the initial setup.
+   - If the splashscreen animation starts, then the reset didn't work!

--- a/rpi0/boot/wpa_supplicant.conf.template
+++ b/rpi0/boot/wpa_supplicant.conf.template
@@ -1,0 +1,12 @@
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+# update_config is required to update the WIFI configuration from remote-software
+update_config=1
+country=<2 letter ISO 3166-1 country code: DK, DE, NL, CH, US, UK, ...>
+
+# fast_reauth might be required if you have multiple access points or roaming
+#fast_reauth=1
+
+network={
+    ssid="<Name of your wireless LAN>"
+    psk="<Password for your wireless LAN>"
+}

--- a/rpi0/genimage.cfg
+++ b/rpi0/genimage.cfg
@@ -11,7 +11,9 @@ image boot.vfat {
       "rpi-firmware/fixup.dat",
       "rpi-firmware/start.elf",
       "overlays",
-      "kernel.img"
+      "kernel.img",
+      "README.md",
+      "wpa_supplicant.conf.template"
     }
   }
   size = 32M

--- a/rpi0/post-build.sh
+++ b/rpi0/post-build.sh
@@ -3,7 +3,7 @@
 set -u
 set -e
 
-SCRIPT_DIR=$(dirname $0)
+SCRIPT_DIR="$(dirname $0)"
 
 # Add a console on tty1
 if [ -e ${TARGET_DIR}/etc/inittab ]; then

--- a/rpi0/post-image.sh
+++ b/rpi0/post-image.sh
@@ -3,6 +3,7 @@
 # abort if a command fails
 set -e
 
+SCRIPT_DIR="$(dirname $0)"
 BOARD_DIR="$(dirname $0)"
 BOARD_NAME="$(basename ${BOARD_DIR})"
 GENIMAGE_CFG="${BOARD_DIR}/genimage.cfg"
@@ -15,14 +16,28 @@ if [ "$SKIP_BUILD_IMAGE" = "y" ]; then
     exit
 fi
 
+# gather files for boot partition
 cp ${BOARD_DIR}/boot/*.txt ${BINARIES_DIR}/
 cp ${TARGET_DIR}/opt/yio/app/config.json.def ${BINARIES_DIR}/config.json
+cp ${BOARD_DIR}/boot/*.md ${BINARIES_DIR}/
+cp ${BOARD_DIR}/boot/*.template ${BINARIES_DIR}/
 
 mkdir -p ${BINARIES_DIR}/overlays
 cp ${BOARD_DIR}/boot/overlays/*.dtbo ${BINARIES_DIR}/overlays/
 
 cp ${BINARIES_DIR}/zImage ${BINARIES_DIR}/kernel.img
 
+# patch README file with build version and build timestamp
+BUILD_VERSION=$("$SCRIPT_DIR/git-version.sh" "$BR2_EXTERNAL/version")
+BUILD_DATE=$(date --iso-8601=seconds)
+
+echo "Setting build version in README.md: $BUILD_VERSION"
+sed -i "s/\$BUILD_VERSION/$BUILD_VERSION/g" ${BINARIES_DIR}/README.md
+sed -i "s/\$BUILD_DATE/$BUILD_DATE/g" ${BINARIES_DIR}/README.md
+# for our Windows users:
+unix2dos ${BINARIES_DIR}/README.md
+
+# create SD card image
 rm -rf "${GENIMAGE_TMP}"
 
 genimage                           \

--- a/yio-remote/Config.in
+++ b/yio-remote/Config.in
@@ -31,7 +31,7 @@ if BR2_PACKAGE_YIO_REMOTE
 # Custom versions can be enabled with: BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 config BR2_PACKAGE_YIO_REMOTE_SOFTWARE_VERSION_DEF
 	string
-	default "v0.5.3"
+	default "v0.6.0"
 config BR2_PACKAGE_YIO_WEB_CONFIGURATOR_VERSION_DEF
 	string
 	default "v0.2.1"

--- a/yio-remote/yio-remote-software/v0.6.0/yio-remote-software.hash
+++ b/yio-remote/yio-remote-software/v0.6.0/yio-remote-software.hash
@@ -1,0 +1,3 @@
+sha256  20637c4e1fcc7a2ec4b10759b0fd878b1285969853a36fafca35135fba5d46ae  YIO-remote-software-v0.6.0-RPi0-debug.tar
+sha256  f4d483b2619598d6674fa9e73e5523cb88e3294e5bcc59914c88ef139a4db200  YIO-remote-software-v0.6.0-RPi0-release.tar
+sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE


### PR DESCRIPTION
Automatically create a Bluetooth serial console after boot up if a
marker file on the boot partition is found. Marker file name: btconsole

This closes #55