### PR TITLE
build: Build all YIO components from GitHub source

### DIFF
--- a/Technology_research.md
+++ b/Technology_research.md
@@ -1,0 +1,57 @@
+# Technology Research
+
+The following technologies were / are investigated for finding an easy and automated solution to build the RPi image.
+
+## Build and Use external Toolchain with Buildroot
+
+A separate toolchain would speed up the build process. This can easily be achieved with [Buildroot Submodule](https://github.com/Openwide-Ingenierie/buildroot-submodule#using-buildroot-submodule-to-build-a-toolchain-separately).
+
+A *make clean* will no longer erase the compiler toolchain and therefore speedup a new full build. Since Qt is required to build the YIO remote projects the complete Qt tools would have to be included as well to use the separate toolchain for the remote-software and -plugin projects. Therefore we are not using this feature to keep it simple and not to introduce another build dependency.
+
+Using an external toolchain involves the following changes:
+
+1. Dedicated Makefile for the toolchain: `Makefile.toolchain`
+
+        PROJECT_NAME := toolchain
+        include common.mk
+
+2. A toolchain subproject with the toolchain configuration: `toolchain/defconfig`
+
+        BR2_arm=y
+        BR2_arm1176jzf_s=y
+        BR2_DL_DIR="$(HOME)/buildroot/dl"
+        BR2_PACKAGE_OVERRIDE_FILE="$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/local.mk"
+        BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/patch"
+        BR2_TOOLCHAIN_BUILDROOT_GLIBC=y
+        BR2_KERNEL_HEADERS_CUSTOM_TARBALL=y
+        BR2_KERNEL_HEADERS_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/raspberrypi-kernel_1.20190401-1.tar.gz"
+        BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_14=y
+        BR2_TOOLCHAIN_BUILDROOT_CXX=y
+        BR2_INIT_NONE=y
+        # BR2_PACKAGE_BUSYBOX is not set
+        # BR2_TARGET_ROOTFS_TAR is not set
+
+3. Referencing the external toolchain in the main project: `rpi0/defconfig`
+
+        BR2_TOOLCHAIN_EXTERNAL=y
+        BR2_TOOLCHAIN_EXTERNAL_PATH="$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/toolchain/output/host/usr"
+        BR2_TOOLCHAIN_EXTERNAL_GCC_8=y
+        BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_14=y
+        BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y
+        BR2_TOOLCHAIN_EXTERNAL_CXX=y
+
+## Vagrant
+
+Vagrant would be perfect for building the RPi image. Everything could be automated and one would only have to type `vagrant up`.
+
+Found issues so far:
+
+- Almost all official Linux boxes have a 'small' 10 GB disk:
+  - Not enough to build the image.
+  - No standard way of extending the disk, or limited to one virtualization provider (vagrant-disksize plugin).
+  - Synced folders don't work because of hard links
+- Serious issues with VirtualBox 6 in combination with newer Ubuntu images
+  - Bootup takes 5+ minutes instead of seconds
+  - Issue is something with the UART console
+
+Vagrant might be investigated again in the future. For now the Docker Image provides an easy way to build on Linux, macOS and Windows.

--- a/yio-remote/Config.in
+++ b/yio-remote/Config.in
@@ -28,10 +28,12 @@ if BR2_PACKAGE_YIO_REMOTE
 
 # Default versions of all YIO components which work together in this remote-os release.
 # All YIO components have their own release channel and version numbers don't relate or indicate a compatible version!
-# Custom versions can be enabled with: BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 config BR2_PACKAGE_YIO_REMOTE_SOFTWARE_VERSION_DEF
 	string
 	default "v0.6.0"
+config BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY_VERSION_DEF
+	string
+	default "v0.5.1"
 config BR2_PACKAGE_YIO_WEB_CONFIGURATOR_VERSION_DEF
 	string
 	default "v0.2.1"
@@ -60,56 +62,6 @@ config BR2_PACKAGE_YIO_INTEGRATION_ROON_VERSION_DEF
 	string
 	default "v0.4.1"
 
-choice
-	prompt "Source"
-	help
-	  Select from where the YIO remote components will be installed.
-	  This only applies to Qt based components, i.e. the web-configurator
-	  will always be packaged from the GitHub sources.
-
-config BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
-	bool "Binary GitHub releases"
-	help
-	  Use binary releases for Qt based components from GitHub repositories.
-	  Attention: the binary releases are only compatible on the Raspberry Pi!
-
-config BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR
-	bool "Binary folder"
-	help
-	  This option allows to specify a local folder containing pre-compiled
-	  Qt binaries for the target platform. The folder must contain debug and
-	  release subdirectories.
-	  Attention: Buildroot will cache the synchronized folder after the first
-	  build. To update the binaries all involved packages must be reconfigured
-	  by executing:
-	  make yio-${PACKAGE_NAME}-reconfigure
-	  or the build directories of all yio packages must be deleted:
-	  rm -Rf rpi0/output/build/yio-*
-	  before building a new image!
-
-# TODO Build from source not yet implemented
-# config BR2_PACKAGE_YIO_REMOTE_GITHUB
-# 	bool "Build from source"
-# 	help
-# 	  Use GitHub source repositories to build YIO components.
-
-endchoice
-
-config BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR_LOCATION
-	string "URL of custom app binary folder"
-	default "~/projects/yio/binaries/linux-gcc-arm"
-	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR
-	help
-	  Local folder containing pre-compiled binaries for the target platform.
-	  The folder must contain debug and release subdirectories.
-	  Attention: Buildroot will cache the synchronized folder after the first
-	  build. To update the binaries all involved packages must be reconfigured
-	  by executing:
-	  make yio-${PACKAGE_NAME}-reconfigure
-	  or the build directories of all yio packages must be deleted:
-	  rm -Rf rpi0/output/build/yio-*
-	  before building a new image!
-
 config BR2_PACKAGE_YIO_REMOTE_DEBUG
 	bool "Debug build"
 	help
@@ -132,6 +84,7 @@ config BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	  remote application and the integration plugins!
 
 source "../yio-remote/yio-remote-software/Config.in"
+source "../yio-remote/yio-integrations-library/Config.in"
 source "../yio-remote/yio-web-configurator/Config.in"
 
 config BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
@@ -149,4 +102,4 @@ source "../yio-remote/yio-integration-openhab/Config.in"
 source "../yio-remote/yio-integration-roon/Config.in"
 source "../yio-remote/yio-integration-openweather/Config.in"
 
-endif
+endif # BR2_PACKAGE_YIO_REMOTE

--- a/yio-remote/yio-integration-bangolufsen/Config.in
+++ b/yio-remote/yio-integration-bangolufsen/Config.in
@@ -3,8 +3,6 @@ if BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
 config BR2_PACKAGE_YIO_INTEGRATION_BANGOLUFSEN
 	bool "Bang & Olufsen integration"
 	default y
-	# only binary GitHub support for now
-	depends on BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
 	help
 	  Includes the YIO Bang & Olufsen integration plugin.
 	  https://github.com/YIO-Remote/integration.bangolufsen
@@ -16,9 +14,11 @@ config BR2_PACKAGE_YIO_INTEGRATION_BANGOLUFSEN_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_INTEGRATION_BANGOLUFSEN_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version. Set version number with 'v' prefix,
-	  e.g. v0.3.0 or v0.4.0
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/integration.bangolufsen/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_INTEGRATION_BANGOLUFSEN_VERSION
 	string

--- a/yio-remote/yio-integration-bangolufsen/v0.1.0/yio-integration-bangolufsen.hash
+++ b/yio-remote/yio-integration-bangolufsen/v0.1.0/yio-integration-bangolufsen.hash
@@ -1,2 +1,0 @@
-sha256  058a51322fcd9760a95d6a0560af281af9f18ecbda60009bcb28ca499ad60eb8  YIO-integration.bangolufsen-v0.1.0-RPi0-release.tar
-sha256  e8077d90a1ee99fc4f538452199f16915b8f1637c480c1228134d53ea4f82786  YIO-integration.bangolufsen-v0.1.0-RPi0-debug.tar

--- a/yio-remote/yio-integration-bangolufsen/v0.2.2/yio-integration-bangolufsen.hash
+++ b/yio-remote/yio-integration-bangolufsen/v0.2.2/yio-integration-bangolufsen.hash
@@ -1,3 +1,2 @@
-sha256  0daa27bd7d8045595af8047f8e7c62fabde74ebdf63f03d0fd321d953741fbb4  YIO-integration.bangolufsen-v0.2.2-RPi0-debug.tar
-sha256  31dc90e23788a79a273b868e8c441f045887c5cc52f60e3f92528d6baded5c66  YIO-integration.bangolufsen-v0.2.2-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+none  xxx  yio-integration-bangolufsen-v0.2.2.tar.gz

--- a/yio-remote/yio-integration-bangolufsen/yio-integration-bangolufsen.mk
+++ b/yio-remote/yio-integration-bangolufsen/yio-integration-bangolufsen.mk
@@ -4,48 +4,42 @@
 #
 ################################################################################
 
-# Attention: this makefile doesn't work yet for building the integration from source!
-# Only the binary release installation is implemented. Source build will be included in a future release.
-
 YIO_INTEGRATION_BANGOLUFSEN_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_INTEGRATION_BANGOLUFSEN_VERSION))
 YIO_INTEGRATION_BANGOLUFSEN_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 YIO_INTEGRATION_BANGOLUFSEN_LICENSE = GPL-3.0
 YIO_INTEGRATION_BANGOLUFSEN_LICENSE_FILES = LICENSE
+YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5tools qt5websockets yio-integrations-library
+YIO_INTEGRATION_BANGOLUFSEN_SITE = git://github.com/YIO-Remote/integration.bangolufsen.git
 
-# Compute mandatory _SOURCE and _SITE from the configuration
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
-    ifeq ($(YIO_INTEGRATION_BANGOLUFSEN_DEBUG),y)
-        YIO_INTEGRATION_BANGOLUFSEN_SOURCE = YIO-integration.bangolufsen-$(YIO_INTEGRATION_BANGOLUFSEN_VERSION)-RPi0-debug.tar
-    else
-        YIO_INTEGRATION_BANGOLUFSEN_SOURCE = YIO-integration.bangolufsen-$(YIO_INTEGRATION_BANGOLUFSEN_VERSION)-RPi0-release.tar
-    endif
-    YIO_INTEGRATION_BANGOLUFSEN_SITE = https://github.com/YIO-Remote/integration.bangolufsen/releases/download/$(YIO_INTEGRATION_BANGOLUFSEN_VERSION)
+ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
+    YIO_INTEGRATION_BANGOLUFSEN_QMAKE_ARGS = "CONFIG+=debug"
 else
-    YIO_INTEGRATION_BANGOLUFSEN_SITE = git://github.com/YIO-Remote/integration.bangolufsen.git
+    YIO_INTEGRATION_BANGOLUFSEN_QMAKE_ARGS = "CONFIG+=release"
 endif
 
 ################################################################################
 # CONFIGURE_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_BANGOLUFSEN_CONFIGURE_CMDS
-    @echo "Extracting release archive..."
-    (cd $(@D); tar -xvf app.tar.gz);
+    @echo "Creating Makefile..."
+    @mkdir -p $(@D)/build
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(HOST_DIR)/bin/qmake $(@D) $(YIO_INTEGRATION_BANGOLUFSEN_QMAKE_ARGS))
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(MAKE) qmake_all)
 endef
-endif
 
 ################################################################################
 # BUILD_CMDS
 ################################################################################
+define YIO_INTEGRATION_BANGOLUFSEN_BUILD_CMDS
+    ($(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/build)
+endef
 
 ################################################################################
 # INSTALL_TARGET_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_BANGOLUFSEN_INSTALL_TARGET_CMDS
     $(INSTALL) -d $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0644 $(@D)/app/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
+    $(INSTALL) -m 0644 $(@D)/bin/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
 endef
-endif
 
 $(eval $(generic-package))

--- a/yio-remote/yio-integration-dock/Config.in
+++ b/yio-remote/yio-integration-dock/Config.in
@@ -3,8 +3,6 @@ if BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
 config BR2_PACKAGE_YIO_INTEGRATION_DOCK
 	bool "Dock integration"
 	default y
-	# only binary GitHub support for now
-	depends on BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
 	help
 	  Includes the YIO dock integration plugin.
 	  https://github.com/YIO-Remote/integration.dock
@@ -16,9 +14,11 @@ config BR2_PACKAGE_YIO_INTEGRATION_DOCK_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_INTEGRATION_DOCK_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version. Set version number with 'v' prefix,
-	  e.g. v0.3.0 or v0.4.0
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/integration.dock/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_INTEGRATION_DOCK_VERSION
 	string

--- a/yio-remote/yio-integration-dock/v0.4.0/yio-integration-dock.hash
+++ b/yio-remote/yio-integration-dock/v0.4.0/yio-integration-dock.hash
@@ -1,2 +1,0 @@
-sha256  8618bd0d01f7feb4366aa157f749a19d697f256bd7e481e46e6b590e89edd966  YIO-integration.dock-v0.4.0-RPi0-release.tar
-sha256  5f8c4219db3ca47a33ba10ebe7ce898977c409fc96a64f392c36012e692725ff  YIO-integration.dock-v0.4.0-RPi0-debug.tar

--- a/yio-remote/yio-integration-dock/v0.6.0/yio-integration-dock.hash
+++ b/yio-remote/yio-integration-dock/v0.6.0/yio-integration-dock.hash
@@ -1,2 +1,0 @@
-sha256  d9dbf6800113a607226fa62b3da6caaee4365d2896527e8804ff14dc340b9bd9  YIO-integration.dock-v0.6.0-RPi0-debug.tar
-sha256  a9f1f197aae9c4f9f2646e83e4208377c6f80fd1033bdd1ed2b6bd39ae09c414  YIO-integration.dock-v0.6.0-RPi0-release.tar

--- a/yio-remote/yio-integration-dock/v0.6.1/yio-integration-dock.hash
+++ b/yio-remote/yio-integration-dock/v0.6.1/yio-integration-dock.hash
@@ -1,3 +1,2 @@
-sha256  9c2860521b1c193cb7e3f375f54d11b5f2e9c0b0660badfd3318c21e96fe7a6d  YIO-integration.dock-v0.6.1-RPi0-debug.tar
-sha256  21632868aae03335026bb18b75be5b84b67b6bd25b6692df8407c5bfaac0aaef  YIO-integration.dock-v0.6.1-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+none  xxx  yio-integration-dock-v0.6.1.tar.gz

--- a/yio-remote/yio-integration-dock/yio-integration-dock.mk
+++ b/yio-remote/yio-integration-dock/yio-integration-dock.mk
@@ -4,48 +4,42 @@
 #
 ################################################################################
 
-# Attention: this makefile doesn't work yet for building the integration from source!
-# Only the binary release installation is implemented. Source build will be included in a future release.
-
 YIO_INTEGRATION_DOCK_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_INTEGRATION_DOCK_VERSION))
 YIO_INTEGRATION_DOCK_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 YIO_INTEGRATION_DOCK_LICENSE = GPL-3.0
 YIO_INTEGRATION_DOCK_LICENSE_FILES = LICENSE
+YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5tools qt5websockets yio-integrations-library
+YIO_INTEGRATION_DOCK_SITE = git://github.com/YIO-Remote/integration.dock.git
 
-# Compute mandatory _SOURCE and _SITE from the configuration
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
-    ifeq ($(YIO_INTEGRATION_DOCK_DEBUG),y)
-        YIO_INTEGRATION_DOCK_SOURCE = YIO-integration.dock-$(YIO_INTEGRATION_DOCK_VERSION)-RPi0-debug.tar
-    else
-        YIO_INTEGRATION_DOCK_SOURCE = YIO-integration.dock-$(YIO_INTEGRATION_DOCK_VERSION)-RPi0-release.tar
-    endif
-    YIO_INTEGRATION_DOCK_SITE = https://github.com/YIO-Remote/integration.dock/releases/download/$(YIO_INTEGRATION_DOCK_VERSION)
+ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
+    YIO_INTEGRATION_DOCK_QMAKE_ARGS = "CONFIG+=debug"
 else
-    YIO_INTEGRATION_DOCK_SITE = git://github.com/YIO-Remote/integration.dock.git
+    YIO_INTEGRATION_DOCK_QMAKE_ARGS = "CONFIG+=release"
 endif
 
 ################################################################################
 # CONFIGURE_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_DOCK_CONFIGURE_CMDS
-    @echo "Extracting release archive..."
-    (cd $(@D); tar -xvf app.tar.gz);
+    @echo "Creating Makefile..."
+    @mkdir -p $(@D)/build
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(HOST_DIR)/bin/qmake $(@D) $(YIO_INTEGRATION_DOCK_QMAKE_ARGS))
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(MAKE) qmake_all)
 endef
-endif
 
 ################################################################################
 # BUILD_CMDS
 ################################################################################
+define YIO_INTEGRATION_DOCK_BUILD_CMDS
+    ($(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/build)
+endef
 
 ################################################################################
 # INSTALL_TARGET_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_DOCK_INSTALL_TARGET_CMDS
     $(INSTALL) -d $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0644 $(@D)/app/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
+    $(INSTALL) -m 0644 $(@D)/bin/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
 endef
-endif
 
 $(eval $(generic-package))

--- a/yio-remote/yio-integration-homeassistant/Config.in
+++ b/yio-remote/yio-integration-homeassistant/Config.in
@@ -3,8 +3,6 @@ if BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
 config BR2_PACKAGE_YIO_INTEGRATION_HOMEASSISTANT
 	bool "Home Assistant integration"
 	default y
-	# only binary GitHub support for now
-	depends on BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
 	help
 	  Includes the YIO Home Assistant integration plugin.
 	  https://github.com/YIO-Remote/integration.home-assistant
@@ -16,9 +14,11 @@ config BR2_PACKAGE_YIO_INTEGRATION_HOMEASSISTANT_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_INTEGRATION_HOMEASSISTANT_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version. Set version number with 'v' prefix,
-	  e.g. v0.3.0 or v0.4.0
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/integration.home-assistant/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_INTEGRATION_HOMEASSISTANT_VERSION
 	string

--- a/yio-remote/yio-integration-homeassistant/v0.4.0/yio-integration-homeassistant.hash
+++ b/yio-remote/yio-integration-homeassistant/v0.4.0/yio-integration-homeassistant.hash
@@ -1,2 +1,0 @@
-sha256  52dc1e7b21176292e65487719cb07d5d1ef31966b04b8a34543ef58f0fc6ab2b  YIO-integration.home-assistant-v0.4.0-RPi0-release.tar
-sha256  689cf0336e31955e8c9f729d2667308752a1d3e07f20a253e9fd1ca15a32c386  YIO-integration.home-assistant-v0.4.0-RPi0-debug.tar

--- a/yio-remote/yio-integration-homeassistant/v0.5.0/yio-integration-homeassistant.hash
+++ b/yio-remote/yio-integration-homeassistant/v0.5.0/yio-integration-homeassistant.hash
@@ -1,2 +1,0 @@
-sha256  6e991f1a78ac48bdc7f4746cc64da516bcc797ead0c5d6fe9e3e02a24570b124  YIO-integration.home-assistant-v0.5.0-RPi0-debug.tar
-sha256  0edb033d3edef1e67e87a24a77b75a0e4907fbef16208fbb0a4217be406613ea  YIO-integration.home-assistant-v0.5.0-RPi0-release.tar

--- a/yio-remote/yio-integration-homeassistant/v0.5.3/yio-integration-homeassistant.hash
+++ b/yio-remote/yio-integration-homeassistant/v0.5.3/yio-integration-homeassistant.hash
@@ -1,3 +1,2 @@
-sha256  4f2bfc3edebc76cccf9e90cabc3882d90681e399bbe3ea6fc5b142d9a188af9d  YIO-integration.home-assistant-v0.5.3-RPi0-debug.tar
-sha256  23fc428f5cb08c26bd6e107bbe749159ae35424453ab9087515845d52b6c6769  YIO-integration.home-assistant-v0.5.3-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+none  xxx  yio-integration-homeassistant-v0.5.3.tar.gz

--- a/yio-remote/yio-integration-homeassistant/yio-integration-homeassistant.mk
+++ b/yio-remote/yio-integration-homeassistant/yio-integration-homeassistant.mk
@@ -4,48 +4,42 @@
 #
 ################################################################################
 
-# Attention: this makefile doesn't work yet for building the integration from source!
-# Only the binary release installation is implemented. Source build will be included in a future release.
-
 YIO_INTEGRATION_HOMEASSISTANT_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_INTEGRATION_HOMEASSISTANT_VERSION))
 YIO_INTEGRATION_HOMEASSISTANT_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 YIO_INTEGRATION_HOMEASSISTANT_LICENSE = GPL-3.0
 YIO_INTEGRATION_HOMEASSISTANT_LICENSE_FILES = LICENSE
+YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5tools qt5websockets yio-integrations-library
+YIO_INTEGRATION_HOMEASSISTANT_SITE = git://github.com/YIO-Remote/integration.home-assistant.git
 
-# Compute mandatory _SOURCE and _SITE from the configuration
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
-    ifeq ($(YIO_INTEGRATION_HOMEASSISTANT_DEBUG),y)
-        YIO_INTEGRATION_HOMEASSISTANT_SOURCE = YIO-integration.home-assistant-$(YIO_INTEGRATION_HOMEASSISTANT_VERSION)-RPi0-debug.tar
-    else
-        YIO_INTEGRATION_HOMEASSISTANT_SOURCE = YIO-integration.home-assistant-$(YIO_INTEGRATION_HOMEASSISTANT_VERSION)-RPi0-release.tar
-    endif
-    YIO_INTEGRATION_HOMEASSISTANT_SITE = https://github.com/YIO-Remote/integration.home-assistant/releases/download/$(YIO_INTEGRATION_HOMEASSISTANT_VERSION)
+ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
+    YIO_INTEGRATION_HOMEASSISTANT_QMAKE_ARGS = "CONFIG+=debug"
 else
-    YIO_INTEGRATION_HOMEASSISTANT_SITE = git://github.com/YIO-Remote/integration.home-assistant.git
+    YIO_INTEGRATION_HOMEASSISTANT_QMAKE_ARGS = "CONFIG+=release"
 endif
 
 ################################################################################
 # CONFIGURE_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_HOMEASSISTANT_CONFIGURE_CMDS
-    @echo "Extracting release archive..."
-    (cd $(@D); tar -xvf app.tar.gz);
+    @echo "Creating Makefile..."
+    @mkdir -p $(@D)/build
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(HOST_DIR)/bin/qmake $(@D) $(YIO_INTEGRATION_HOMEASSISTANT_QMAKE_ARGS))
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(MAKE) qmake_all)
 endef
-endif
 
 ################################################################################
 # BUILD_CMDS
 ################################################################################
+define YIO_INTEGRATION_HOMEASSISTANT_BUILD_CMDS
+    ($(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/build)
+endef
 
 ################################################################################
 # INSTALL_TARGET_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_HOMEASSISTANT_INSTALL_TARGET_CMDS
     $(INSTALL) -d $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0644 $(@D)/app/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
+    $(INSTALL) -m 0644 $(@D)/bin/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
 endef
-endif
 
 $(eval $(generic-package))

--- a/yio-remote/yio-integration-homey/Config.in
+++ b/yio-remote/yio-integration-homey/Config.in
@@ -3,8 +3,6 @@ if BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
 config BR2_PACKAGE_YIO_INTEGRATION_HOMEY
 	bool "Homey integration"
 	default y
-	# only binary GitHub support for now
-	depends on BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
 	help
 	  Includes the YIO Homey integration plugin.
 	  https://github.com/YIO-Remote/integration.homey
@@ -16,9 +14,11 @@ config BR2_PACKAGE_YIO_INTEGRATION_HOMEY_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_INTEGRATION_HOMEY_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version. Set version number with 'v' prefix,
-	  e.g. v0.3.0 or v0.4.0
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/integration.homey/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_INTEGRATION_HOMEY_VERSION
 	string

--- a/yio-remote/yio-integration-homey/v0.4.0/yio-integration-homey.hash
+++ b/yio-remote/yio-integration-homey/v0.4.0/yio-integration-homey.hash
@@ -1,2 +1,0 @@
-sha256  8aa77cd6de089c789a0d1a6cde6c1540ad93f95fcea152934678ad431c945adb  YIO-integration.homey-v0.4.0-RPi0-release.tar
-sha256  0296d6a382eddff45aa8410c08e07eeec9238c2b53f1d0d1ba04b3312f3f8d56  YIO-integration.homey-v0.4.0-RPi0-debug.tar

--- a/yio-remote/yio-integration-homey/v0.5.0/yio-integration-homey.hash
+++ b/yio-remote/yio-integration-homey/v0.5.0/yio-integration-homey.hash
@@ -1,2 +1,0 @@
-sha256  7ec1c979f42709fae1044a5fff8deb10e579809dafbd03802b6380b914ad1880  YIO-integration.homey-v0.5.0-RPi0-debug.tar
-sha256  be75d7ebf4171849061abcada2811816e3b1fec3b1dfebc29f351a6eec90200a  YIO-integration.homey-v0.5.0-RPi0-release.tar

--- a/yio-remote/yio-integration-homey/v0.5.1/yio-integration-homey.hash
+++ b/yio-remote/yio-integration-homey/v0.5.1/yio-integration-homey.hash
@@ -1,3 +1,2 @@
-sha256  df432aebb74d4d3e79b55f260bed3fe529c222a05e81340929d3b4496efde913  YIO-integration.homey-v0.5.1-RPi0-debug.tar
-sha256  74f66301e1e9f40750d8905a7a459941f50d52d529a47a3a1f7770921b47c021  YIO-integration.homey-v0.5.1-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+none  xxx  yio-integration-homey-v0.5.1.tar.gz

--- a/yio-remote/yio-integration-homey/yio-integration-homey.mk
+++ b/yio-remote/yio-integration-homey/yio-integration-homey.mk
@@ -4,48 +4,42 @@
 #
 ################################################################################
 
-# Attention: this makefile doesn't work yet for building the integration from source!
-# Only the binary release installation is implemented. Source build will be included in a future release.
-
 YIO_INTEGRATION_HOMEY_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_INTEGRATION_HOMEY_VERSION))
 YIO_INTEGRATION_HOMEY_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 YIO_INTEGRATION_HOMEY_LICENSE = GPL-3.0
 YIO_INTEGRATION_HOMEY_LICENSE_FILES = LICENSE
+YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5tools qt5websockets yio-integrations-library
+YIO_INTEGRATION_HOMEY_SITE = git://github.com/YIO-Remote/integration.homey.git
 
-# Compute mandatory _SOURCE and _SITE from the configuration
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
-    ifeq ($(YIO_INTEGRATION_HOMEY_DEBUG),y)
-        YIO_INTEGRATION_HOMEY_SOURCE = YIO-integration.homey-$(YIO_INTEGRATION_HOMEY_VERSION)-RPi0-debug.tar
-    else
-        YIO_INTEGRATION_HOMEY_SOURCE = YIO-integration.homey-$(YIO_INTEGRATION_HOMEY_VERSION)-RPi0-release.tar
-    endif
-    YIO_INTEGRATION_HOMEY_SITE = https://github.com/YIO-Remote/integration.homey/releases/download/$(YIO_INTEGRATION_HOMEY_VERSION)
+ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
+    YIO_INTEGRATION_HOMEY_QMAKE_ARGS = "CONFIG+=debug"
 else
-    YIO_INTEGRATION_HOMEY_SITE = git://github.com/YIO-Remote/integration.homey.git
+    YIO_INTEGRATION_HOMEY_QMAKE_ARGS = "CONFIG+=release"
 endif
 
 ################################################################################
 # CONFIGURE_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_HOMEY_CONFIGURE_CMDS
-    @echo "Extracting release archive..."
-    (cd $(@D); tar -xvf app.tar.gz);
+    @echo "Creating Makefile..."
+    @mkdir -p $(@D)/build
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(HOST_DIR)/bin/qmake $(@D) $(YIO_INTEGRATION_HOMEY_QMAKE_ARGS))
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(MAKE) qmake_all)
 endef
-endif
 
 ################################################################################
 # BUILD_CMDS
 ################################################################################
+define YIO_INTEGRATION_HOMEY_BUILD_CMDS
+    ($(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/build)
+endef
 
 ################################################################################
 # INSTALL_TARGET_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_HOMEY_INSTALL_TARGET_CMDS
     $(INSTALL) -d $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0644 $(@D)/app/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
+    $(INSTALL) -m 0644 $(@D)/bin/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
 endef
-endif
 
 $(eval $(generic-package))

--- a/yio-remote/yio-integration-openhab/Config.in
+++ b/yio-remote/yio-integration-openhab/Config.in
@@ -3,8 +3,6 @@ if BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
 config BR2_PACKAGE_YIO_INTEGRATION_OPENHAB
 	bool "openHAB integration (UNDER DEVELOPMENT)"
 	default n
-	# only binary GitHub support for now
-	depends on BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
 	help
 	  Includes the YIO openHAB integration plugin.
 	  https://github.com/YIO-Remote/integration.openhab
@@ -16,9 +14,11 @@ config BR2_PACKAGE_YIO_INTEGRATION_OPENHAB_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_INTEGRATION_OPENHAB_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version. Set version number with 'v' prefix,
-	  e.g. v0.3.0 or v0.4.0
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/integration.openhab/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_INTEGRATION_OPENHAB_VERSION
 	string

--- a/yio-remote/yio-integration-openhab/v0.4.0/yio-integration-openhab.hash
+++ b/yio-remote/yio-integration-openhab/v0.4.0/yio-integration-openhab.hash
@@ -1,2 +1,0 @@
-sha256  e74fb397f2f1515dedc3257d23f95dac34b8218274eb36225bd4935c65276509  YIO-integration.openhab-v0.4.0-RPi0-release.tar
-sha256  fff8a4c0d792e9c5d57355113416eb09c120f2cd8a4385ee7b03ed401893da42  YIO-integration.openhab-v0.4.0-RPi0-debug.tar

--- a/yio-remote/yio-integration-openhab/v0.5.1/yio-integration-openhab.hash
+++ b/yio-remote/yio-integration-openhab/v0.5.1/yio-integration-openhab.hash
@@ -1,3 +1,2 @@
-sha256  e0a9c4e65492336438c647b92ae389e2bf4169c701877046861d8e76b4313fc9  YIO-integration.openhab-v0.5.1-RPi0-debug.tar
-sha256  ae65ffc79b03958cc59155d50b94ad285c847cedfd23061d50d0d97ff6efbd29  YIO-integration.openhab-v0.5.1-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+none  xxx  yio-integration-openhab-v0.5.1.tar.gz

--- a/yio-remote/yio-integration-openweather/Config.in
+++ b/yio-remote/yio-integration-openweather/Config.in
@@ -3,8 +3,6 @@ if BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
 config BR2_PACKAGE_YIO_INTEGRATION_OPENWEATHER
 	bool "OpenWeather integration (EXPERIMENTAL!)"
 	default n
-	# only binary GitHub support for now
-	depends on BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
 	help
 	  Includes the YIO OpenWeather integration plugin.
 	  https://github.com/YIO-Remote/integration.openweather
@@ -16,9 +14,11 @@ config BR2_PACKAGE_YIO_INTEGRATION_OPENWEATHER_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_INTEGRATION_OPENWEATHER_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version. Set version number with 'v' prefix,
-	  e.g. v0.3.0 or v0.4.0
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/integration.openweather/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_INTEGRATION_OPENWEATHER_VERSION
 	string

--- a/yio-remote/yio-integration-openweather/v0.4.0/yio-integration-openweather.hash
+++ b/yio-remote/yio-integration-openweather/v0.4.0/yio-integration-openweather.hash
@@ -1,2 +1,0 @@
-sha256  8171856c427c51c498f22444b23a4a11f5b087d7d6d309c5eb20fed2a14371a3  YIO-integration.openweather-v0.4.0-RPi0-release.tar
-sha256  414dd6cc3b813484009d756b3cb1f9b27af85654ac463182b55fe7fc4939187a  YIO-integration.openweather-v0.4.0-RPi0-debug.tar

--- a/yio-remote/yio-integration-openweather/v0.5.0/yio-integration-openweather.hash
+++ b/yio-remote/yio-integration-openweather/v0.5.0/yio-integration-openweather.hash
@@ -1,2 +1,0 @@
-sha256  b805d883a8c8b7d9486d1917c80dc55b6872be42684bda7507c679651013f116  YIO-integration.openweather-v0.5.0-RPi0-debug.tar
-sha256  42d2176701f37a1913f7248aa7c8869c78590b240e314120a8d9174ca9e59db3  YIO-integration.openweather-v0.5.0-RPi0-release.tar

--- a/yio-remote/yio-integration-openweather/v0.5.1/yio-integration-openweather.hash
+++ b/yio-remote/yio-integration-openweather/v0.5.1/yio-integration-openweather.hash
@@ -1,3 +1,2 @@
-sha256  c42050b67c4e047e098e63cb0ac0381719551d26b10a567974480f4fea26c6ac  YIO-integration.openweather-v0.5.1-RPi0-debug.tar
-sha256  243e71effedbc04437db9d9f78e9c1d5a60e75f21078ede445c6f31254a1f273  YIO-integration.openweather-v0.5.1-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+none  xxx  yio-integration-openweather-v0.5.1.tar.gz

--- a/yio-remote/yio-integration-openweather/yio-integration-openweather.mk
+++ b/yio-remote/yio-integration-openweather/yio-integration-openweather.mk
@@ -4,48 +4,42 @@
 #
 ################################################################################
 
-# Attention: this makefile doesn't work yet for building the integration from source!
-# Only the binary release installation is implemented. Source build will be included in a future release.
-
 YIO_INTEGRATION_OPENWEATHER_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_INTEGRATION_OPENWEATHER_VERSION))
 YIO_INTEGRATION_OPENWEATHER_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 YIO_INTEGRATION_OPENWEATHER_LICENSE = GPL-3.0
 YIO_INTEGRATION_OPENWEATHER_LICENSE_FILES = LICENSE
+YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5tools yio-integrations-library
+YIO_INTEGRATION_OPENWEATHER_SITE = git://github.com/YIO-Remote/integration.openweather.git
 
-# Compute mandatory _SOURCE and _SITE from the configuration
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
-    ifeq ($(YIO_INTEGRATION_OPENWEATHER_DEBUG),y)
-        YIO_INTEGRATION_OPENWEATHER_SOURCE = YIO-integration.openweather-$(YIO_INTEGRATION_OPENWEATHER_VERSION)-RPi0-debug.tar
-    else
-        YIO_INTEGRATION_OPENWEATHER_SOURCE = YIO-integration.openweather-$(YIO_INTEGRATION_OPENWEATHER_VERSION)-RPi0-release.tar
-    endif
-    YIO_INTEGRATION_OPENWEATHER_SITE = https://github.com/YIO-Remote/integration.openweather/releases/download/$(YIO_INTEGRATION_OPENWEATHER_VERSION)
+ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
+    YIO_INTEGRATION_OPENWEATHER_QMAKE_ARGS = "CONFIG+=debug"
 else
-    YIO_INTEGRATION_OPENWEATHER_SITE = git://github.com/YIO-Remote/integration.openweather.git
+    YIO_INTEGRATION_OPENWEATHER_QMAKE_ARGS = "CONFIG+=release"
 endif
 
 ################################################################################
 # CONFIGURE_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_OPENWEATHER_CONFIGURE_CMDS
-    @echo "Extracting release archive..."
-    (cd $(@D); tar -xvf app.tar.gz);
+    @echo "Creating Makefile..."
+    @mkdir -p $(@D)/build
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(HOST_DIR)/bin/qmake $(@D) $(YIO_INTEGRATION_OPENWEATHER_QMAKE_ARGS))
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(MAKE) qmake_all)
 endef
-endif
 
 ################################################################################
 # BUILD_CMDS
 ################################################################################
+define YIO_INTEGRATION_OPENWEATHER_BUILD_CMDS
+    ($(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/build)
+endef
 
 ################################################################################
 # INSTALL_TARGET_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_OPENWEATHER_INSTALL_TARGET_CMDS
     $(INSTALL) -d $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0644 $(@D)/app/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
+    $(INSTALL) -m 0644 $(@D)/bin/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
 endef
-endif
 
 $(eval $(generic-package))

--- a/yio-remote/yio-integration-roon/Config.in
+++ b/yio-remote/yio-integration-roon/Config.in
@@ -3,8 +3,6 @@ if BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
 config BR2_PACKAGE_YIO_INTEGRATION_ROON
 	bool "Roon integration (UNDER DEVELOPMENT)"
 	default n
-	# only binary GitHub support for now
-	depends on BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
 	help
 	  Includes the YIO Roon integration plugin.
 	  https://github.com/YIO-Remote/integration.roon
@@ -16,9 +14,11 @@ config BR2_PACKAGE_YIO_INTEGRATION_ROON_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_INTEGRATION_ROON_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version. Set version number with 'v' prefix,
-	  e.g. v0.3.0 or v0.4.0
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/integration.roon/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_INTEGRATION_ROON_VERSION
 	string

--- a/yio-remote/yio-integration-roon/v0.3.0/yio-integration-roon.hash
+++ b/yio-remote/yio-integration-roon/v0.3.0/yio-integration-roon.hash
@@ -1,2 +1,0 @@
-sha256  ff71c934e25a19f503471176f770298c9bd2d695fe57f3985b280b7564815a19  YIO-integration.roon-v0.3.0-RPi0-release.tar
-sha256  b2e2cea970b516f73c0f6cfc57bddefad946b0ed24fd6f1849c9c967c07405b7  YIO-integration.roon-v0.3.0-RPi0-debug.tar

--- a/yio-remote/yio-integration-roon/v0.4.0/yio-integration-roon.hash
+++ b/yio-remote/yio-integration-roon/v0.4.0/yio-integration-roon.hash
@@ -1,2 +1,0 @@
-sha256  544a598c52bf022a404b5d977065da42305fa9cd4699398c04815bfe5391e3bc  YIO-integration.roon-v0.4.0-RPi0-debug.tar
-sha256  5eb03192426e6211bd8fa314fc14c6aa9f7b2b8a6e75ed2b16322f51628b9418  YIO-integration.roon-v0.4.0-RPi0-release.tar

--- a/yio-remote/yio-integration-roon/v0.4.1/yio-integration-roon.hash
+++ b/yio-remote/yio-integration-roon/v0.4.1/yio-integration-roon.hash
@@ -1,3 +1,2 @@
-sha256  55d4d36bddc7fc1c3fab29f0f4db1a618fe76eb44e464be860a962708c6d34de  YIO-integration.roon-v0.4.1-RPi0-debug.tar
-sha256  d393010460b4828ba763ffe7cf57daaa937e43dec4a056ca1c4903d578c8c2e0  YIO-integration.roon-v0.4.1-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+none  xxx  yio-integration-roon-v0.4.1.tar.gz

--- a/yio-remote/yio-integration-roon/yio-integration-roon.mk
+++ b/yio-remote/yio-integration-roon/yio-integration-roon.mk
@@ -4,48 +4,42 @@
 #
 ################################################################################
 
-# Attention: this makefile doesn't work yet for building the integration from source!
-# Only the binary release installation is implemented. Source build will be included in a future release.
-
 YIO_INTEGRATION_ROON_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_INTEGRATION_ROON_VERSION))
 YIO_INTEGRATION_ROON_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 YIO_INTEGRATION_ROON_LICENSE = GPL-3.0
 YIO_INTEGRATION_ROON_LICENSE_FILES = LICENSE
+YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5tools qt5websockets yio-integrations-library
+YIO_INTEGRATION_ROON_SITE = git://github.com/YIO-Remote/integration.roon.git
 
-# Compute mandatory _SOURCE and _SITE from the configuration
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
-    ifeq ($(YIO_INTEGRATION_ROON_DEBUG),y)
-        YIO_INTEGRATION_ROON_SOURCE = YIO-integration.roon-$(YIO_INTEGRATION_ROON_VERSION)-RPi0-debug.tar
-    else
-        YIO_INTEGRATION_ROON_SOURCE = YIO-integration.roon-$(YIO_INTEGRATION_ROON_VERSION)-RPi0-release.tar
-    endif
-    YIO_INTEGRATION_ROON_SITE = https://github.com/YIO-Remote/integration.roon/releases/download/$(YIO_INTEGRATION_ROON_VERSION)
+ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
+    YIO_INTEGRATION_ROON_QMAKE_ARGS = "CONFIG+=debug"
 else
-    YIO_INTEGRATION_ROON_SITE = git://github.com/YIO-Remote/integration.roon.git
+    YIO_INTEGRATION_ROON_QMAKE_ARGS = "CONFIG+=release"
 endif
 
 ################################################################################
 # CONFIGURE_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_ROON_CONFIGURE_CMDS
-    @echo "Extracting release archive..."
-    (cd $(@D); tar -xvf app.tar.gz);
+    @echo "Creating Makefile..."
+    @mkdir -p $(@D)/build
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(HOST_DIR)/bin/qmake $(@D) $(YIO_INTEGRATION_ROON_QMAKE_ARGS))
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(MAKE) qmake_all)
 endef
-endif
 
 ################################################################################
 # BUILD_CMDS
 ################################################################################
+define YIO_INTEGRATION_ROON_BUILD_CMDS
+    ($(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/build)
+endef
 
 ################################################################################
 # INSTALL_TARGET_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_ROON_INSTALL_TARGET_CMDS
     $(INSTALL) -d $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0644 $(@D)/app/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
+    $(INSTALL) -m 0644 $(@D)/bin/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
 endef
-endif
 
 $(eval $(generic-package))

--- a/yio-remote/yio-integration-spotify/Config.in
+++ b/yio-remote/yio-integration-spotify/Config.in
@@ -3,8 +3,6 @@ if BR2_PACKAGE_YIO_REMOTE_INTEGRATIONS
 config BR2_PACKAGE_YIO_INTEGRATION_SPOTIFY
 	bool "Spotify integration"
 	default y
-	# only binary GitHub support for now
-	depends on BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE
 	help
 	  Includes the YIO Spotify integration plugin.
 	  https://github.com/YIO-Remote/integration.spotify
@@ -16,9 +14,11 @@ config BR2_PACKAGE_YIO_INTEGRATION_SPOTIFY_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_INTEGRATION_SPOTIFY_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version. Set version number with 'v' prefix,
-	  e.g. v0.3.0 or v0.4.0
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/integration.spotify/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_INTEGRATION_SPOTIFY_VERSION
 	string

--- a/yio-remote/yio-integration-spotify/v0.4.0/yio-integration-spotify.hash
+++ b/yio-remote/yio-integration-spotify/v0.4.0/yio-integration-spotify.hash
@@ -1,2 +1,0 @@
-sha256  e35a95aa1c83238abf6741b2b80c5a4574d44db05cd6e05988b9701079823b95  YIO-integration.spotify-v0.4.0-RPi0-release.tar
-sha256  f627ee5b9efdbc22dba9e06e1877004b48a4323cb95bafca36e9565bbd029878  YIO-integration.spotify-v0.4.0-RPi0-debug.tar

--- a/yio-remote/yio-integration-spotify/v0.5.0/yio-integration-spotify.hash
+++ b/yio-remote/yio-integration-spotify/v0.5.0/yio-integration-spotify.hash
@@ -1,3 +1,0 @@
-sha256  c98c37e98534f06321ee37cbb41c440860e8c05fb3a312d97e2423066c45e15c  YIO-integration.spotify-v0.5.0-RPi0-debug.tar
-sha256  c99fe792973b73ba0e2d0cb9bbdc2a7c64dc568d38433386f2720d0bcffc5b50  YIO-integration.spotify-v0.5.0-RPi0-release.tar
-sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE

--- a/yio-remote/yio-integration-spotify/v0.5.1/yio-integration-spotify.hash
+++ b/yio-remote/yio-integration-spotify/v0.5.1/yio-integration-spotify.hash
@@ -1,3 +1,2 @@
-sha256  0a06f79e11c07ffee537a0496680442478bc2e3435e36fb385769c06125a5df8  YIO-integration.spotify-v0.5.1-RPi0-debug.tar
-sha256  b38e4282c9b681496831dfc57e8561cd4ec748e2a427436aca2804257de3fb9c  YIO-integration.spotify-v0.5.1-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+none  xxx  yio-integration-spotify-v0.5.1.tar.gz

--- a/yio-remote/yio-integration-spotify/yio-integration-spotify.mk
+++ b/yio-remote/yio-integration-spotify/yio-integration-spotify.mk
@@ -4,48 +4,42 @@
 #
 ################################################################################
 
-# Attention: this makefile doesn't work yet for building the integration from source!
-# Only the binary release installation is implemented. Source build will be included in a future release.
-
 YIO_INTEGRATION_SPOTIFY_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_INTEGRATION_SPOTIFY_VERSION))
 YIO_INTEGRATION_SPOTIFY_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 YIO_INTEGRATION_SPOTIFY_LICENSE = GPL-3.0
 YIO_INTEGRATION_SPOTIFY_LICENSE_FILES = LICENSE
+YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5tools yio-integrations-library
+YIO_INTEGRATION_SPOTIFY_SITE = git://github.com/YIO-Remote/integration.spotify.git
 
-# Compute mandatory _SOURCE and _SITE from the configuration
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
-    ifeq ($(YIO_INTEGRATION_SPOTIFY_DEBUG),y)
-        YIO_INTEGRATION_SPOTIFY_SOURCE = YIO-integration.spotify-$(YIO_INTEGRATION_SPOTIFY_VERSION)-RPi0-debug.tar
-    else
-        YIO_INTEGRATION_SPOTIFY_SOURCE = YIO-integration.spotify-$(YIO_INTEGRATION_SPOTIFY_VERSION)-RPi0-release.tar
-    endif
-    YIO_INTEGRATION_SPOTIFY_SITE = https://github.com/YIO-Remote/integration.spotify/releases/download/$(YIO_INTEGRATION_SPOTIFY_VERSION)
+ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
+    YIO_INTEGRATION_SPOTIFY_QMAKE_ARGS = "CONFIG+=debug"
 else
-    YIO_INTEGRATION_SPOTIFY_SITE = git://github.com/YIO-Remote/integration.spotify.git
+    YIO_INTEGRATION_SPOTIFY_QMAKE_ARGS = "CONFIG+=release"
 endif
 
 ################################################################################
 # CONFIGURE_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_SPOTIFY_CONFIGURE_CMDS
-    @echo "Extracting release archive..."
-    (cd $(@D); tar -xvf app.tar.gz);
+    @echo "Creating Makefile..."
+    @mkdir -p $(@D)/build
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(HOST_DIR)/bin/qmake $(@D) $(YIO_INTEGRATION_SPOTIFY_QMAKE_ARGS))
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(MAKE) qmake_all)
 endef
-endif
 
 ################################################################################
 # BUILD_CMDS
 ################################################################################
+define YIO_INTEGRATION_SPOTIFY_BUILD_CMDS
+    ($(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/build)
+endef
 
 ################################################################################
 # INSTALL_TARGET_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_INTEGRATION_SPOTIFY_INSTALL_TARGET_CMDS
     $(INSTALL) -d $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0644 $(@D)/app/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
+    $(INSTALL) -m 0644 $(@D)/bin/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
 endef
-endif
 
 $(eval $(generic-package))

--- a/yio-remote/yio-integrations-library/Config.in
+++ b/yio-remote/yio-integrations-library/Config.in
@@ -1,0 +1,27 @@
+config BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY
+	bool "Integration library"
+	default y
+	help
+	  Includes the YIO integrations library.
+	  https://github.com/YIO-Remote/integrations.library
+
+if BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY
+
+config BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY_CUSTOM_VERSION
+	string "Custom version"
+	default BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY_VERSION_DEF
+	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
+	help
+	  Custom version. Either a GitHub tag or commit hash.
+	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
+	  See https://github.com/YIO-Remote/integrations.library/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
+
+config BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY_VERSION
+	string
+	default BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY_CUSTOM_VERSION \
+		if BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
+	default BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY_VERSION_DEF
+
+endif # BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY

--- a/yio-remote/yio-integrations-library/yio-integrations-library.mk
+++ b/yio-remote/yio-integrations-library/yio-integrations-library.mk
@@ -1,0 +1,34 @@
+################################################################################
+#
+# YIO integrations-library
+#
+################################################################################
+
+YIO_INTEGRATIONS_LIBRARY_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_INTEGRATIONS_LIBRARY_VERSION))
+YIO_INTEGRATIONS_LIBRARY_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
+YIO_INTEGRATIONS_LIBRARY_SITE = git://github.com/YIO-Remote/integrations.library.git
+YIO_INTEGRATIONS_LIBRARY_LICENSE = GPL-3.0
+YIO_INTEGRATIONS_LIBRARY_LICENSE_FILES = LICENSE
+YIO_INTEGRATIONS_LIBRARY_INSTALL_STAGING = YES
+YIO_INTEGRATIONS_LIBRARY_INSTALL_TARGET = NO
+
+
+################################################################################
+# CONFIGURE_CMDS
+################################################################################
+
+################################################################################
+# BUILD_CMDS
+################################################################################
+
+################################################################################
+# INSTALL_TARGET_CMDS
+################################################################################
+
+define YIO_INTEGRATIONS_LIBRARY_INSTALL_STAGING_CMDS
+    $(INSTALL) -d 0755 "$(STAGING_DIR)/usr/include/yio/integrations.library"
+    $(INSTALL) -m 0644 $(@D)/*.pri "$(STAGING_DIR)/usr/include/yio/integrations.library"
+	cd $(@D) && find src -type f -exec $(INSTALL) -Dm 644 "{}" "$(STAGING_DIR)/usr/include/yio/integrations.library/{}" \;
+endef
+
+$(eval $(generic-package))

--- a/yio-remote/yio-remote-software/Config.in
+++ b/yio-remote/yio-remote-software/Config.in
@@ -10,13 +10,14 @@ config BR2_PACKAGE_YIO_REMOTE_SOFTWARE_CUSTOM_VERSION
 	default BR2_PACKAGE_YIO_REMOTE_SOFTWARE_VERSION_DEF
 	depends on BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
 	help
-	  Custom version.
+	  Custom version. Either a GitHub tag or commit hash.
 	  Set version number with 'v' prefix, e.g. v0.3.0 or v0.4.0
 	  See https://github.com/YIO-Remote/remote-software/releases
+	  Attention: Git branch names are not supported!
+	  See Buildroot manual for details.
 
 config BR2_PACKAGE_YIO_REMOTE_SOFTWARE_VERSION
 	string
 	default BR2_PACKAGE_YIO_REMOTE_SOFTWARE_CUSTOM_VERSION \
 		if BR2_PACKAGE_YIO_REMOTE_CUSTOM_VERSION
-	default "custom-bin" if BR2_PACKAGE_YIO_REMOTE_SOFTWARE_CUSTOM_BIN_DIR
 	default BR2_PACKAGE_YIO_REMOTE_SOFTWARE_VERSION_DEF

--- a/yio-remote/yio-remote-software/v0.3.0/yio-remote-software.hash
+++ b/yio-remote/yio-remote-software/v0.3.0/yio-remote-software.hash
@@ -1,2 +1,0 @@
-sha256  a3f5ad354b6e8aa0b0793417115b217e3898bba61c047df10d5118b3c1019021  YIO-remote-software-v0.3.0-RPi0-release.tar
-sha256  bca912cd52e689dfbc75edf7c6beb580deff36a529a6011111c4494d4a95a032  YIO-remote-software-v0.3.0-RPi0-debug.tar

--- a/yio-remote/yio-remote-software/v0.5.2/yio-remote-software.hash
+++ b/yio-remote/yio-remote-software/v0.5.2/yio-remote-software.hash
@@ -1,2 +1,0 @@
-sha256  85c49bbf98ee58fd76875344a093c299d7d23fee2b3ca9c8340fc5f26515d802  YIO-remote-software-v0.5.2-RPi0-debug.tar
-sha256  b9c6596b5e3b5024e4e2691e741ad6b75af8e1e9419499084bdccc84be2e4dfd  YIO-remote-software-v0.5.2-RPi0-release.tar

--- a/yio-remote/yio-remote-software/v0.5.3/yio-remote-software.hash
+++ b/yio-remote/yio-remote-software/v0.5.3/yio-remote-software.hash
@@ -1,3 +1,0 @@
-sha256  1364a049ec0d959a5a123d5c2dc6814a73d6bab3a7e4aceca8cab161c214a614  YIO-remote-software-v0.5.3-RPi0-debug.tar
-sha256  8c3b3a839b729550a2f3c6947fec5aedd022924ee6fe3de166edda9259ef9b82  YIO-remote-software-v0.5.3-RPi0-release.tar
-sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE

--- a/yio-remote/yio-remote-software/v0.6.0/yio-remote-software.hash
+++ b/yio-remote/yio-remote-software/v0.6.0/yio-remote-software.hash
@@ -1,3 +1,2 @@
-sha256  20637c4e1fcc7a2ec4b10759b0fd878b1285969853a36fafca35135fba5d46ae  YIO-remote-software-v0.6.0-RPi0-debug.tar
-sha256  f4d483b2619598d6674fa9e73e5523cb88e3294e5bcc59914c88ef139a4db200  YIO-remote-software-v0.6.0-RPi0-release.tar
 sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  LICENSE
+sha256  48e4bef943985501be3b84d943821b6ff105bb943ac60d388cfcc78ae766076e  yio-remote-software-v0.6.0.tar.gz

--- a/yio-remote/yio-remote-software/yio-remote-software.hash
+++ b/yio-remote/yio-remote-software/yio-remote-software.hash
@@ -1,2 +1,0 @@
-# This hash file is not used; instead, update the
-# hash files in the per-version sub-directories.

--- a/yio-remote/yio-remote-software/yio-remote-software.mk
+++ b/yio-remote/yio-remote-software/yio-remote-software.mk
@@ -4,46 +4,12 @@
 #
 ################################################################################
 
-# Attention: this makefile doesn't work yet for building yio-remote-software from source!
-# Only the binary release installations are working.
-# The included source build options are a preparation for a future release.
-
 YIO_REMOTE_SOFTWARE_VERSION = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_SOFTWARE_VERSION))
 YIO_REMOTE_SOFTWARE_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 YIO_REMOTE_SOFTWARE_LICENSE = GPL-3.0
 YIO_REMOTE_SOFTWARE_LICENSE_FILES = LICENSE
-YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5graphicaleffects qt5imageformats qt5quickcontrols qt5quickcontrols2 qt5tools qt5virtualkeyboard qt5websockets
-
-# maybe useful to download integrations.library?
-#YIO_REMOTE_SOFTWARE_EXTRA_DOWNLOADS
-
-# Compute mandatory _SOURCE and _SITE from the configuration
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
-    ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
-        YIO_REMOTE_SOFTWARE_SOURCE = YIO-remote-software-$(YIO_REMOTE_SOFTWARE_VERSION)-RPi0-debug.tar
-    else
-        YIO_REMOTE_SOFTWARE_SOURCE = YIO-remote-software-$(YIO_REMOTE_SOFTWARE_VERSION)-RPi0-release.tar
-    endif
-    YIO_REMOTE_SOFTWARE_SITE = https://github.com/YIO-Remote/remote-software/releases/download/$(YIO_REMOTE_SOFTWARE_VERSION)
-else ifeq ($(BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR),y)
-    YIO_REMOTE_SOFTWARE_SOURCE = dummy
-    ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
-        YIO_REMOTE_SOFTWARE_SITE = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR_LOCATION))/debug
-    else
-        YIO_REMOTE_SOFTWARE_SITE = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR_LOCATION))/release
-    endif
-    YIO_REMOTE_SOFTWARE_SITE_METHOD = local
-# else ifeq ($(BR2_PACKAGE_YIO_REMOTE_SOFTWARE_CUSTOM_SRC_DIR),y)
-#     YIO_REMOTE_SOFTWARE_SOURCE = dummy
-#     YIO_REMOTE_SOFTWARE_SITE = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_CUSTOM_SRC_DIR_LOCATION))
-#     YIO_REMOTE_SOFTWARE_SITE_METHOD = local
-# else ifeq ($(BR2_PACKAGE_YIO_REMOTE_SOFTWARE_CUSTOM_TARBALL),y)
-#     YIO_REMOTE_SOFTWARE_TARBALL = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_CUSTOM_TARBALL_LOCATION))
-#     YIO_REMOTE_SOFTWARE_SITE = $(patsubst %/,%,$(dir $(YIO_REMOTE_SOFTWARE_TARBALL)))
-#     YIO_REMOTE_SOFTWARE_SOURCE = $(notdir $(YIO_REMOTE_SOFTWARE_TARBALL))
-else
-    YIO_REMOTE_SOFTWARE_SITE = git://github.com/YIO-Remote/remote-software.git
-endif
+YIO_REMOTE_SOFTWARE_DEPENDENCIES = qt5base qt5connectivity qt5graphicaleffects qt5imageformats qt5quickcontrols qt5quickcontrols2 qt5tools qt5virtualkeyboard qt5websockets yio-integrations-library
+YIO_REMOTE_SOFTWARE_SITE = git://github.com/YIO-Remote/remote-software.git
 
 ifeq ($(YIO_REMOTE_SOFTWARE_DEBUG),y)
     YIO_REMOTE_SOFTWARE_QMAKE_ARGS = "CONFIG+=debug CONFIG+=qml_debug"
@@ -54,88 +20,35 @@ endif
 ################################################################################
 # PRE_CONFIGURE_HOOKS
 ################################################################################
-# ifeq ($(BR2_PACKAGE_YIO_REMOTE_SOFTWARE_CUSTOM_SRC_DIR),y)
-# define YIO_REMOTE_SOFTWARE_PRE_CONFIGURE_FIXUP
-#     @rm -Rf $(@D)/build
-#     @rm -f $(@D)/translations/*.qm
-#     @rm -Rf $(@D)/bin
-# endef
-
-# YIO_REMOTE_SOFTWARE_PRE_CONFIGURE_HOOKS += YIO_REMOTE_SOFTWARE_PRE_CONFIGURE_FIXUP
-# endif
 
 ################################################################################
 # CONFIGURE_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_REMOTE_SOFTWARE_CONFIGURE_CMDS
-    @echo "Extracting release archive..."
-    (cd $(@D); tar -xvf app.tar.gz);
-endef
-else ifneq ($(BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR),y)
-define YIO_REMOTE_SOFTWARE_CONFIGURE_CMDS
-    @if [ "$(BR2_PACKAGE_YIO_REMOTE_SOFTWARE_QT_LINGUIST)" = "y" ]; then \
-        echo "Creating translation files outside qmake build..."; \
-        (cd $(@D); $(TARGET_MAKE_ENV) $(HOST_DIR)/bin/lupdate remote.pro); \
-        (cd $(@D); $(TARGET_MAKE_ENV) $(HOST_DIR)/bin/lrelease remote.pro); \
-    fi
     @echo "Creating Makefile..."
     @mkdir -p $(@D)/build
-    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin $(HOST_DIR)/bin/qmake $(@D) $(YIO_REMOTE_SOFTWARE_QMAKE_ARGS))
-    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin $(MAKE) qmake_all)
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(HOST_DIR)/bin/qmake $(@D) $(YIO_REMOTE_SOFTWARE_QMAKE_ARGS))
+    (cd $(@D)/build; $(TARGET_MAKE_ENV) YIO_BIN=$(@D)/bin YIO_SRC="$(STAGING_DIR)/usr/include/yio" $(MAKE) qmake_all)
 endef
-endif
 
 ################################################################################
 # BUILD_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_REMOTE_SOFTWARE_BUILD_CMDS
-    @echo "No build required for binary GitHub release"
-endef
-else ifeq ($(BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR),y)
-define YIO_REMOTE_SOFTWARE_BUILD_CMDS
-    @echo "No build required with custom binary directory: $(YIO_REMOTE_SOFTWARE_SITE)"
-endef
-else
-define YIO_REMOTE_SOFTWARE_BUILD_CMDS
-    @echo "Using custom source directory: $(YIO_REMOTE_SOFTWARE_SITE)"
     ($(TARGET_MAKE_ENV) $(MAKE) -C $(@D)/build)
 endef
-endif
 
 ################################################################################
 # INSTALL_TARGET_CMDS
 ################################################################################
-ifeq ($(BR2_PACKAGE_YIO_REMOTE_BIN_RELEASE),y)
 define YIO_REMOTE_SOFTWARE_INSTALL_TARGET_CMDS
-    $(INSTALL) -d $(TARGET_DIR)/opt/yio/app/icons $(TARGET_DIR)/opt/yio/app/fonts $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0755 $(@D)/app/remote $(TARGET_DIR)/opt/yio/app
-    $(INSTALL) -m 0644 $(@D)/app/*.json $(TARGET_DIR)/opt/yio/app
-    $(INSTALL) -m 0644 $(@D)/version.txt $(TARGET_DIR)/opt/yio/app
-    mv $(TARGET_DIR)/opt/yio/app/config.json $(TARGET_DIR)/opt/yio/app/config.json.def
-    $(INSTALL) -m 0644 $(@D)/app/icons/* $(TARGET_DIR)/opt/yio/app/icons
-    $(INSTALL) -m 0644 $(@D)/app/fonts/* $(TARGET_DIR)/opt/yio/app/fonts
-endef
-else ifeq ($(BR2_PACKAGE_YIO_REMOTE_CUSTOM_BIN_DIR),y)
-define YIO_REMOTE_SOFTWARE_INSTALL_TARGET_CMDS
-    $(INSTALL) -d $(TARGET_DIR)/opt/yio/app/icons $(TARGET_DIR)/opt/yio/app/fonts $(TARGET_DIR)/opt/yio/app-plugins
-    $(INSTALL) -m 0755 $(@D)/remote $(TARGET_DIR)/opt/yio/app
-    $(INSTALL) -m 0644 $(@D)/*.json $(TARGET_DIR)/opt/yio/app
-    mv $(TARGET_DIR)/opt/yio/app/config.json $(TARGET_DIR)/opt/yio/app/config.json.def
-    $(INSTALL) -m 0644 $(@D)/icons/* $(TARGET_DIR)/opt/yio/app/icons
-    $(INSTALL) -m 0644 $(@D)/fonts/* $(TARGET_DIR)/opt/yio/app/fonts
-    $(INSTALL) -m 0644 $(@D)/plugins/* $(TARGET_DIR)/opt/yio/app-plugins
-endef
-else
-define YIO_REMOTE_SOFTWARE_INSTALL_TARGET_CMDS
-    $(INSTALL) -d $(TARGET_DIR)/opt/yio/app/icons $(TARGET_DIR)/opt/yio/app/fonts $(TARGET_DIR)/opt/yio/app-plugins
+    $(INSTALL) -d 0755 $(TARGET_DIR)/opt/yio/app/icons $(TARGET_DIR)/opt/yio/app/fonts $(TARGET_DIR)/opt/yio/app-plugins
     $(INSTALL) -m 0755 $(@D)/bin/remote $(TARGET_DIR)/opt/yio/app; \
-    $(INSTALL) -m 0644 $(@D)/*.json $(TARGET_DIR)/opt/yio/app
+    $(INSTALL) -m 0644 $(@D)/bin/*.json $(TARGET_DIR)/opt/yio/app
+    $(INSTALL) -m 0644 $(@D)/build/version.txt $(TARGET_DIR)/opt/yio/app
     mv $(TARGET_DIR)/opt/yio/app/config.json $(TARGET_DIR)/opt/yio/app/config.json.def
-    $(INSTALL) -m 0644 $(@D)/icons/* $(TARGET_DIR)/opt/yio/app/icons
-    $(INSTALL) -m 0644 $(@D)/fonts/* $(TARGET_DIR)/opt/yio/app/fonts
+    $(INSTALL) -m 0644 $(@D)/bin/icons/* $(TARGET_DIR)/opt/yio/app/icons
+    $(INSTALL) -m 0644 $(@D)/bin/fonts/* $(TARGET_DIR)/opt/yio/app/fonts
 endef
-endif
 
 $(eval $(generic-package))

--- a/yio-remote/yio-remote.mk
+++ b/yio-remote/yio-remote.mk
@@ -8,6 +8,7 @@
 YIO_REMOTE_DEBUG = $(call qstrip,$(BR2_PACKAGE_YIO_REMOTE_DEBUG))
 
 include ../yio-remote/yio-remote-software/yio-remote-software.mk
+include ../yio-remote/yio-integrations-library/yio-integrations-library.mk
 include ../yio-remote/yio-web-configurator/yio-web-configurator.mk
 
 include ../yio-remote/yio-integration-dock/yio-integration-dock.mk


### PR DESCRIPTION
All YIO components are now built from their GitHub repository sources, and no longer downloaded as binary releases.
Version numbers are still the same and usually directly relate to a GitHub release, which has the same number as Git tag. Furthermore, one can now also use commit hashes for a specific development build.
Not only is this more "Buildroot style", but also allows to adapt to new Qt versions more quickly or use other build environments.

Using binary YIO releases are no longer supported.

This supports #3  in using newer Qt versions. It resolves the chicken-egg issue and no longer depends on GitHub binary releases.