### PR TITLE
build: Remove SKIP_BUILD_IMAGE env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ Further `make` arguments:
 
 | **Option**               | **Description**  |
 |--------------------------|------------------|
-| `SKIP_BUILD_IMAGE=y`     | Skip SD card image creation |
 | `BR2_JLEVEL=n`           | Adjust level of build parallelism. n = number of cores. Default: number of CPUs + 1 |
 
 ### Troubleshooting

--- a/buildroot-external/external.mk
+++ b/buildroot-external/external.mk
@@ -1,8 +1,3 @@
 # Makefiles used by all subprojects
 
-# flag to skip creating the SD card image
-# used for the initial buildroot build to create the toolchain used for Qt compilation
-SKIP_BUILD_IMAGE=n
-export SKIP_BUILD_IMAGE
-
 include $(sort $(wildcard $(BR2_EXTERNAL_YIOS_PATH)/package/*/*.mk))

--- a/buildroot-external/scripts/post-image.sh
+++ b/buildroot-external/scripts/post-image.sh
@@ -21,11 +21,6 @@ HOOK_FILE="$3"
 
 touch ${BR2_EXTERNAL_YIOS_PATH}/.toolchain-ready
 
-if [ "$SKIP_BUILD_IMAGE" = "y" ]; then
-    echo "WARN: not building SD card image: disabled with SKIP_BUILD_IMAGE"
-    exit
-fi
-
 BUILD_VERSION=$("$SCRIPT_DIR/git-version.sh" "$BR2_EXTERNAL/version")
 BUILD_DATE=$(date --iso-8601=seconds)
 


### PR DESCRIPTION
The Buildroot build directory should not be used as toolchain.
Use the official SDK option to build an external toolchain instead:
https://buildroot.org/downloads/manual/manual.html#_cross_compilation_toolchain

After PR approval, I'll update the WiKi guide.

This closes #62